### PR TITLE
Calculate text height with max size / WordBreak

### DIFF
--- a/FlexibleMessageBox/FlexibleMessageBox.cs
+++ b/FlexibleMessageBox/FlexibleMessageBox.cs
@@ -566,8 +566,17 @@ namespace JR.Utils.GUI.Forms
                 var stringRows = GetStringRows(text);
                 if (stringRows == null) return;
 
-                //Calculate whole text height
-                var textHeight = TextRenderer.MeasureText(text, FONT).Height;
+                //Calculate margins
+                var marginWidth = flexibleMessageBoxForm.Width - flexibleMessageBoxForm.richTextBoxMessage.Width;
+                var marginHeight = flexibleMessageBoxForm.Height - flexibleMessageBoxForm.richTextBoxMessage.Height;
+
+                flexibleMessageBoxForm.richTextBoxMessage.MaximumSize = new Size(flexibleMessageBoxForm.MaximumSize.Width - marginWidth,
+                                                                                 flexibleMessageBoxForm.MaximumSize.Height - marginHeight);
+
+                //Calculate whole text height considering maximum size for richTextBoxMessage and WordBreak
+                TextFormatFlags textFormatFlags = new TextFormatFlags();
+                textFormatFlags |= TextFormatFlags.WordBreak;
+                var textHeight = TextRenderer.MeasureText(text, FONT, flexibleMessageBoxForm.richTextBoxMessage.MaximumSize, textFormatFlags).Height;
                     
                 //Calculate width for longest text line
                 const int SCROLLBAR_WIDTH_OFFSET = 15;
@@ -575,11 +584,6 @@ namespace JR.Utils.GUI.Forms
                 var captionWidth = TextRenderer.MeasureText(caption, SystemFonts.CaptionFont).Width;
                 var textWidth = Math.Max(longestTextRowWidth + SCROLLBAR_WIDTH_OFFSET, captionWidth);
                 
-                //Calculate margins
-                var marginWidth = flexibleMessageBoxForm.Width - flexibleMessageBoxForm.richTextBoxMessage.Width;
-                var marginHeight = flexibleMessageBoxForm.Height - flexibleMessageBoxForm.richTextBoxMessage.Height;
-                int magicAdd = 12;
-                marginHeight += magicAdd;
                 //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
                 flexibleMessageBoxForm.Size = new Size(textWidth + marginWidth,
                                                        textHeight + marginHeight);

--- a/FlexibleMessageBoxDemo/Form1.Designer.cs
+++ b/FlexibleMessageBoxDemo/Form1.Designer.cs
@@ -35,6 +35,7 @@ namespace FlexibleMessageBoxDemo
             this.btnNormal = new System.Windows.Forms.Button();
             this.btnOneLine = new System.Windows.Forms.Button();
             this.button3 = new System.Windows.Forms.Button();
+            this.buttonLongLine = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // button1
@@ -72,10 +73,18 @@ namespace FlexibleMessageBoxDemo
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
+            // buttonLongLine
+            // 
+            resources.ApplyResources(this.buttonLongLine, "buttonLongLine");
+            this.buttonLongLine.Name = "buttonLongLine";
+            this.buttonLongLine.UseVisualStyleBackColor = true;
+            this.buttonLongLine.Click += new System.EventHandler(this.buttonLongLine_Click);
+            // 
             // Form1
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.buttonLongLine);
             this.Controls.Add(this.button3);
             this.Controls.Add(this.btnOneLine);
             this.Controls.Add(this.btnNormal);
@@ -93,6 +102,7 @@ namespace FlexibleMessageBoxDemo
         private System.Windows.Forms.Button btnNormal;
         private System.Windows.Forms.Button btnOneLine;
         private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button buttonLongLine;
     }
 }
 

--- a/FlexibleMessageBoxDemo/Form1.cs
+++ b/FlexibleMessageBoxDemo/Form1.cs
@@ -82,6 +82,18 @@ namespace FlexibleMessageBoxDemo
                 MessageBoxIcon.Information);
         }
 
+        private void buttonLongLine_Click(object sender, EventArgs e)
+        {
+            double MAX_WIDTH_FACTOR_start = FlexibleMessageBox.MAX_WIDTH_FACTOR;
+            FlexibleMessageBox.MAX_WIDTH_FACTOR = 0.3f;
+            FlexibleMessageBox.Show(this,
+                "MyApp v1.0.1 this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - this is a long line message - ",
+                "MyApp",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
+            FlexibleMessageBox.MAX_WIDTH_FACTOR = MAX_WIDTH_FACTOR_start;
+        }
+
         private void button3_Click(object sender, EventArgs e)
         {
         }

--- a/FlexibleMessageBoxDemo/Form1.resx
+++ b/FlexibleMessageBoxDemo/Form1.resx
@@ -141,7 +141,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="button2.Location" type="System.Drawing.Point, System.Drawing">
     <value>392, 132</value>
@@ -165,7 +165,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;button2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="btnNormal.Location" type="System.Drawing.Point, System.Drawing">
     <value>64, 64</value>
@@ -189,7 +189,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnNormal.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnOneLine.Location" type="System.Drawing.Point, System.Drawing">
     <value>190, 64</value>
@@ -213,7 +213,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOneLine.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="button3.Location" type="System.Drawing.Point, System.Drawing">
     <value>502, 132</value>
@@ -237,6 +237,30 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;button3.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="buttonLongLine.Location" type="System.Drawing.Point, System.Drawing">
+    <value>301, 64</value>
+  </data>
+  <data name="buttonLongLine.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 23</value>
+  </data>
+  <data name="buttonLongLine.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="buttonLongLine.Text" xml:space="preserve">
+    <value>Long Line with MAX_WIDTH_FACTOR=0.3</value>
+  </data>
+  <data name="&gt;&gt;buttonLongLine.Name" xml:space="preserve">
+    <value>buttonLongLine</value>
+  </data>
+  <data name="&gt;&gt;buttonLongLine.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonLongLine.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonLongLine.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -249,7 +273,7 @@
     <value>659, 336</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Meiryo UI, 9pt</value>
+    <value>Microsoft Sans Serif, 9pt</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Form1</value>


### PR DESCRIPTION
Behaviour so far: When width of form is limited and message is too long, message lines are wrapped and scroll bar appears. With this change the width limit and word break is considered when calculating the text height for richTextBoxMessage, so that scrolling is not needed as long as height limit is not exceeded.

magicAdd is removed: seemed to solve a similar problem, but after changing calculation of text height, I could not see a benefit (maybe missed something).

Form1 contains a new button to test this change.